### PR TITLE
Page Section Search: Prevent failure when a pagenames is a prefix

### DIFF
--- a/action.php
+++ b/action.php
@@ -70,7 +70,7 @@ class action_plugin_linksuggest extends DokuWiki_Action_Plugin {
         $data_r = [];
         $link = '';
 
-        if ($hash !== null && count($data) === 1 && $data[0]['type'] === 'f') {
+        if ($hash !== null && $data[0]['type'] === 'f') {
             //if hash is given and a page was found
             $page = $data[0]['id'];
             $meta = p_get_metadata($page, false, METADATA_RENDER_USING_CACHE);


### PR DESCRIPTION
If you have two pages in a namespace with one being a prefix of the other (e.g. "episoden" and "episoden-videos"), adding the # will correctly trigger the page section search. The backend however only returns section results if `count($data) === 1`. So if there are still two results, the plugin will insert a link like `[[#undefined` since it gets page results but expects section results.