### PR TITLE
Enable "dirmatch" for media search

### DIFF
--- a/action.php
+++ b/action.php
@@ -214,7 +214,7 @@ class action_plugin_linksuggest extends DokuWiki_Action_Plugin {
             'sneakyacl' => $conf['sneaky_index'],
         ];
         if ($id) $opts['filematch'] = '^.*\/' . $id;
-        if ($id && false) $opts['dirmatch'] = '^.*\/' . $id;
+        if ($id) $opts['dirmatch'] = '^.*\/' . $id;
         search($data, $conf['mediadir'], 'search_universal', $opts, $nsd);
 
         return $data;


### PR DESCRIPTION
It looks like the "dirmatch" regex is required, otherwise the list of media suggestions does not get smaller the more you type.