### PR TITLE
better autocomplete + setting to disable appending header

### DIFF
--- a/action.php
+++ b/action.php
@@ -21,6 +21,11 @@ class action_plugin_linksuggest extends DokuWiki_Action_Plugin {
     public function register(Doku_Event_Handler $controller) {
         $controller->register_hook('AJAX_CALL_UNKNOWN', 'BEFORE', $this, 'page_link');
         $controller->register_hook('AJAX_CALL_UNKNOWN', 'BEFORE', $this, 'media_link');
+        $controller->register_hook('DOKUWIKI_STARTED', 'AFTER',  $this, '_add_config');
+    }
+    public function _add_config(&$event, $param) {
+        global $JSINFO;
+        $JSINFO['append_header'] = $this->getConf('append_header');
     }
 
     /**

--- a/conf/default.php
+++ b/conf/default.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * Default settings for the linksuggest
+ **/
+
+$conf['append_header'] = 1;

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -1,0 +1,2 @@
+<?php
+$meta['append_header'] = array('onoff');

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -1,0 +1,2 @@
+<?php
+$lang['append_header'] = "If set to true, the plugin adds the header to the end of the link.";

--- a/script.js
+++ b/script.js
@@ -3,8 +3,15 @@ function linksuggest_escape(text) {
     return jQuery('<div/>').text(text).html();
 }
 
+function charAfterCursor() {
+    let editor = jQuery('#wiki__text');
+    let position = editor.prop('selectionStart');
+    return editor.prop('value').substring(position, position+1);
+}
+
 jQuery(function () {
     let $editor = jQuery('#wiki__text');
+
     $editor.textcomplete([
         { //page search
             match:    /\[{2}([\w\-.:~]*)$/,
@@ -74,7 +81,7 @@ jQuery(function () {
                     setTimeout(function () {
                         $editor.data('linksuggest_off', 0);
                     }, 500);
-                    return ['[[' + id, '|' + (item.title ? item.title : '') + ']]'];
+                    return ['[[' + id, (item.title && (JSINFO["append_header"] === 1) ? '|' + item.title : '') + (charAfterCursor() === ']'? '' : ']]')];
                 }
 
             },
@@ -122,7 +129,17 @@ jQuery(function () {
                     $editor.data('linksuggest_off', 0);
                 }, 500);
 
-                return '[[' + link + '#' + toc.hid;
+                 let endChar = charAfterCursor();
+                 console.log(endChar);
+                 if(endChar === '|' || !toc.title) {
+                  return '[[' + link + '#' + toc.hid;
+                 }else{
+                     if(endChar === ']'){
+                         return '[[' + link + '#' + toc.hid + '|' + toc.title;
+                     }else{
+                         return '[[' + link + '#' + toc.hid + '|' + toc.title + ']]';
+                     }
+                 }
             },
             cache:   false
         }, { //media search

--- a/script.js
+++ b/script.js
@@ -9,6 +9,16 @@ function charAfterCursor() {
     return editor.prop('value').substring(position, position+1);
 }
 
+function appendTitle(title) {
+    return (title && JSINFO["append_header"] === 1 && charAfterCursor() !== '|')? '|' + title : '';
+}
+function appendSubtitle(title) {
+    return (title && charAfterCursor() !== '|')? '|' + title : '';
+}
+function appendClosing() {
+    return (charAfterCursor() === ']' || charAfterCursor() === '|')? '' : ']]';
+}
+
 jQuery(function () {
     let $editor = jQuery('#wiki__text');
 
@@ -81,7 +91,7 @@ jQuery(function () {
                     setTimeout(function () {
                         $editor.data('linksuggest_off', 0);
                     }, 500);
-                    return ['[[' + id, (item.title && (JSINFO["append_header"] === 1) ? '|' + item.title : '') + (charAfterCursor() === ']'? '' : ']]')];
+                    return ['[[' + id, appendTitle(item.title) + appendClosing()];
                 }
 
             },
@@ -129,17 +139,7 @@ jQuery(function () {
                     $editor.data('linksuggest_off', 0);
                 }, 500);
 
-                 let endChar = charAfterCursor();
-                 console.log(endChar);
-                 if(endChar === '|' || !toc.title) {
-                  return '[[' + link + '#' + toc.hid;
-                 }else{
-                     if(endChar === ']'){
-                         return '[[' + link + '#' + toc.hid + '|' + toc.title;
-                     }else{
-                         return '[[' + link + '#' + toc.hid + '|' + toc.title + ']]';
-                     }
-                 }
+                return '[[' + link + '#' + toc.hid + appendSubtitle(toc.title) + appendClosing();
             },
             cache:   false
         }, { //media search


### PR DESCRIPTION
fixes #15  and fixes #8 

Basic code taken from: https://github.com/syntaxseed/dokucrypt2/pull/16/files

It seems to work in all cases I could think of.
Title is always appended after '#' (I didn't add a rule for that), as dokuwiki doesn't show a nice title when using it.
but if anyone desires it, a setting for that could also easily be added.